### PR TITLE
添加功能：使用自定义python脚本去重

### DIFF
--- a/MisakaTranslator-WPF/MisakaTranslator-WPF.csproj
+++ b/MisakaTranslator-WPF/MisakaTranslator-WPF.csproj
@@ -474,9 +474,28 @@
     <PackageReference Include="HandyControl">
       <Version>2.4.0</Version>
     </PackageReference>
+    <PackageReference Include="IronPython">
+      <Version>2.7.11</Version>
+    </PackageReference>
     <PackageReference Include="System.Data.SQLite">
       <Version>1.0.112</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.112.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.112.0\build\net46\System.Data.SQLite.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用“NuGet 程序包还原”可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.112.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.112.0\build\net46\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.3.0\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.3.0\build\EntityFramework.targets'))" />
+  </Target>
+  <Import Project="..\packages\EntityFramework.6.3.0\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>
+if not exist $(TargetDir)textRepairPlugins mkdir $(TargetDir)textRepairPlugins
+xcopy /s /y $(ProjectDir)textRepairPlugins $(TargetDir)textRepairPlugins
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/MisakaTranslator-WPF/textRepairPlugins/example.py
+++ b/MisakaTranslator-WPF/textRepairPlugins/example.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+# 不加上面那行就不能写中文注释
+# Iron Python自带了re，如果要使用其他标准库，可以把Python2.7 lib目录下的文件复制到翻译器的lib目录下。
+import re
+
+# 函数名必须是process，接受一个string，返回一个string，其他随意
+def process(source):
+    #去除HTML标签
+    source = re.sub("<[^>]+>", "", source)
+    source = re.sub("&[^;]+;", "", source)
+    #句子去重（根据空格分割句子，取最后一段）
+    parts = [p for p in source.split(" ") if len(p) > 0]
+    return parts[-1] if len(parts) != 0 else ""

--- a/TextRepairLibrary/TextRepairLibrary.csproj
+++ b/TextRepairLibrary/TextRepairLibrary.csproj
@@ -31,6 +31,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IronPython, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.Modules, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.Modules.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.SQLite, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="IronPython.Wpf, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.Wpf.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Dynamic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Dynamic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Scripting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Scripting.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1, processorArchitecture=MSIL">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Scripting.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -43,6 +64,9 @@
   <ItemGroup>
     <Compile Include="TextRepair.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/TextRepairLibrary/packages.config
+++ b/TextRepairLibrary/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DynamicLanguageRuntime" version="1.3.0" targetFramework="net461" />
+  <package id="IronPython" version="2.7.11" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
我搞了一个能让用户用python脚本去重的功能（dll用起来太麻烦了....）

使用方法：
新建一个py文件，里面定义一个函数，函数名必须是process，接受一个字符串，返回一个字符串，文件名随意，放到textRepairPlugins目录下。脚本可以使用正则表达式标准库re，别的标准库大多数都（默认）不支持。整个脚本都在.Net上运行，不需要安装python。注意语言版本是Python2.7，`__init__.py`不能删。

在设置去重方法的时候，翻译器会自动扫描textRepairPlugins目录下所有的python脚本，用户选择一下即可。
我在`textRepairPlugins/example.py`写了一个例子可以参照。
