### PR TITLE
捕获异常

### DIFF
--- a/MisakaTranslator-WPF/MainWindow.xaml.cs
+++ b/MisakaTranslator-WPF/MainWindow.xaml.cs
@@ -388,10 +388,16 @@ namespace MisakaTranslator_WPF {
                 foreach (var process in processes) {
                     for (int j = 0; j < gameInfoList.Count; j++) {
                         string filepath;
-                        try {
+                        try
+                        {
                             filepath = process.MainModule.FileName;
                         }
-                        catch (Win32Exception ex) {
+                        catch (Win32Exception)
+                        {
+                            continue;
+                        }
+                        catch (InvalidOperationException)
+                        {
                             continue;
                         }
 


### PR DESCRIPTION
这个循环过程中可能有进程退出，导致process.MainModule空指针