### PR TITLE
修复Tesseract5无法保存自定义参数的bug

### DIFF
--- a/MisakaTranslator-WPF/SettingsPages/OCRPages/TesseractOCR5SettingsPage.xaml.cs
+++ b/MisakaTranslator-WPF/SettingsPages/OCRPages/TesseractOCR5SettingsPage.xaml.cs
@@ -37,10 +37,10 @@ namespace MisakaTranslator_WPF.SettingsPages.OCRPages
         {
             InitializeComponent();
             PathBox.Text = Common.appSettings.Tesseract5OCR_Path;
+            ArgsBox.Text = Common.appSettings.Tesseract5OCR_Args;
             SelectBox.ItemsSource = itemList;
             SelectBox.SelectedIndex = valueList.IndexOf(Common.appSettings.Tesseract5OCR_Mode);
             SyncModeAndArgs();
-            ArgsBox.Text = Common.appSettings.Tesseract5OCR_Args;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
准确的说是设置保存了，但是每次进入设置界面都会清空自定义参数。
原因是设置SelectBox的时候会触发SelectBox_SelectionChanged()，此时ArgsBox为空，然后把空的值写入了文件