### PR TITLE
修复如果路径中含有特殊字符无法运行程序bug

### DIFF
--- a/MisakaTranslator-WPF/MisakaTranslator-WPF.csproj
+++ b/MisakaTranslator-WPF/MisakaTranslator-WPF.csproj
@@ -309,11 +309,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Resource Include="GuidePages\Completation.png" />
-    <Content Include="lang\en-US.xaml">
+    <Page Include="lang\en-US.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </Page>
     <Page Include="lang\zh-CN.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
如果路径中存在#等特殊字符，会直接打不开程序，调试的时候报找不到en-US.xaml，因为这个文件的打包方式错了