### PR TITLE
更新到2.11

### DIFF
--- a/MisakaTranslator-WPF/Properties/AssemblyInfo.cs
+++ b/MisakaTranslator-WPF/Properties/AssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Windows;
 [assembly : AssemblyCulture("")]
 [assembly : ComVisible(false)]
 [assembly : ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-[assembly : AssemblyVersion("2.10.1.0")]
-[assembly : AssemblyFileVersion("2.10.1.0")]
+[assembly : AssemblyVersion("2.11.0.0")]
+[assembly : AssemblyFileVersion("2.11.0.0")]

--- a/index.html
+++ b/index.html
@@ -1,3 +1,3 @@
 This is AutoUpdateCheck's Page.
-LatestVersion[2.10.1.0]
+LatestVersion[2.11.0.0]
 DownloadPath[https://github.com/hanmin0822/MisakaTranslator/releases]


### PR DESCRIPTION
更新日志：

* 减少了OCR时的内存占用
* 全局OCR时允许按ESC放弃
* 修复了漫画翻译的某些问题
* 修复了去重的某个崩溃问题
