### PR TITLE
添加了源文本分词上色的开关

### DIFF
--- a/MisakaTranslator-WPF/IAppSettings.cs
+++ b/MisakaTranslator-WPF/IAppSettings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/MisakaTranslator-WPF/IAppSettings.cs
+++ b/MisakaTranslator-WPF/IAppSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -393,6 +394,12 @@ namespace MisakaTranslator_WPF
         }
         [Option(Alias = "TranslateFromSetting.isSuperBold", DefaultValue = true)]
         bool TF_SuperBold
+        {
+            get;
+            set;
+        }
+        [Option(Alias = "TranslateFromSetting.isColorful", DefaultValue = true)]
+        bool TF_Colorful
         {
             get;
             set;

--- a/MisakaTranslator-WPF/TransWinSettingsWindow.xaml
+++ b/MisakaTranslator-WPF/TransWinSettingsWindow.xaml
@@ -33,10 +33,11 @@
 					
 					<CheckBox Name="HirakanaCheckBox" Content="{StaticResource TransWinSettingsWin_HirakanaCbox}" Margin="10" HorizontalAlignment="Left"/>
 					
-					
+				
 					<CheckBox Name="KanaBoldCheckBox" Content="{StaticResource TransWinSettingsWin_KanaBoldCbox}" Margin="10" HorizontalAlignment="Left"/>
+                    <CheckBox Name="ColorfulCheckBox" Content="{StaticResource TransWinSettingsWin_ColorfulCbox}" Margin="10" HorizontalAlignment="Left"/>
 
-					<TextBlock Text="{StaticResource TransWinSettingsWin_srcSetNotice}" Margin="10" HorizontalAlignment="Center"/>
+                    <TextBlock Text="{StaticResource TransWinSettingsWin_srcSetNotice}" Margin="10" HorizontalAlignment="Center"/>
 					
                 </StackPanel>
 

--- a/MisakaTranslator-WPF/TransWinSettingsWindow.xaml.cs
+++ b/MisakaTranslator-WPF/TransWinSettingsWindow.xaml.cs
@@ -115,6 +115,10 @@ namespace MisakaTranslator_WPF
                 Common.appSettings.TF_SuperBold = (bool)KanaBoldCheckBox.IsChecked;
             };
 
+            ColorfulCheckBox.Click += delegate
+            {
+                Common.appSettings.TF_Colorful = (bool)ColorfulCheckBox.IsChecked;
+            };
           
 
         }
@@ -156,7 +160,7 @@ namespace MisakaTranslator_WPF
             KanaCheckBox.IsChecked = Common.appSettings.TF_isKanaShow;
             HirakanaCheckBox.IsChecked = Common.appSettings.TF_Hirakana;
             KanaBoldCheckBox.IsChecked = Common.appSettings.TF_SuperBold;
-
+            ColorfulCheckBox.IsChecked = Common.appSettings.TF_Colorful;
         }
 
         private void ChooseColorBtn_Click(object sender, RoutedEventArgs e)

--- a/MisakaTranslator-WPF/TranslateWindow.xaml.cs
+++ b/MisakaTranslator-WPF/TranslateWindow.xaml.cs
@@ -474,26 +474,31 @@ namespace MisakaTranslator_WPF
                             //加入原文的阴影
                         }
 
-
-                        switch (mwi[i].PartOfSpeech)
+                        if (Common.appSettings.TF_Colorful)
                         {
-                            case "名詞":
-                                textBlock.Foreground = Brushes.AliceBlue;
-                                break;
-                            case "助詞":
-                                textBlock.Foreground = Brushes.LightGreen;
-                                break;
-                            case "動詞":
-                                textBlock.Foreground = Brushes.Red;
-                                break;
-                            case "連体詞":
-                                textBlock.Foreground = Brushes.Orange;
-                                break;
-                            default:
-                                textBlock.Foreground = Brushes.White;
-                                break;
+                            switch (mwi[i].PartOfSpeech)
+                            {
+                                case "名詞":
+                                    textBlock.Foreground = Brushes.AliceBlue;
+                                    break;
+                                case "助詞":
+                                    textBlock.Foreground = Brushes.LightGreen;
+                                    break;
+                                case "動詞":
+                                    textBlock.Foreground = Brushes.Red;
+                                    break;
+                                case "連体詞":
+                                    textBlock.Foreground = Brushes.Orange;
+                                    break;
+                                default:
+                                    textBlock.Foreground = Brushes.White;
+                                    break;
+                            }
                         }
-
+                        else
+                        {
+                            textBlock.Foreground = Brushes.White;
+                        }         
 
                         TextBlock superScript = new TextBlock();//假名或注释等的上标标签
                         if (!string.IsNullOrEmpty(SourceTextFont))
@@ -617,7 +622,7 @@ namespace MisakaTranslator_WPF
                           }
                           else
                           {
-                              SecondTransText.Effect = null;
+                              FirstTransText.Effect = null;
                           }
                           //添加第一翻译源的阴影
                       });

--- a/MisakaTranslator-WPF/lang/en-US.xaml
+++ b/MisakaTranslator-WPF/lang/en-US.xaml
@@ -323,6 +323,7 @@
 	<sys:String x:Key="TransWinSettingsWin_HirakanaCbox">使用平假名注音</sys:String>
 
 	<sys:String x:Key="TransWinSettingsWin_KanaBoldCbox">将假名标注加粗</sys:String>
+    <sys:String x:Key="TransWinSettingsWin_ColorfulCbox">开启源文本分词上色</sys:String>
 
 	<sys:String x:Key="MainWindow_AutoUpdateCheck">发现新版本！点击确认进入下载页面，点击取消忽略本次更新提示。</sys:String>
 

--- a/MisakaTranslator-WPF/lang/zh-CN.xaml
+++ b/MisakaTranslator-WPF/lang/zh-CN.xaml
@@ -321,6 +321,7 @@
 	<sys:String x:Key="TransWinSettingsWin_DropShadowCbox">开启文字阴影</sys:String>
 
     <sys:String x:Key="TransWinSettingsWin_KanaCbox">开启日语原文假名标注</sys:String>
+    <sys:String x:Key="TransWinSettingsWin_ColorfulCbox">开启源文本分词上色</sys:String>
 
 
 	<sys:String x:Key="TransWinSettingsWin_HirakanaCbox">使用平假名注音</sys:String>


### PR DESCRIPTION
在翻译界面设置的选框中增加了源文本分词上色的开关，默认字体颜色为白色。
开关关闭效果如下所示。
![image](https://user-images.githubusercontent.com/40874312/197380981-c3bdd698-e3eb-41d7-815f-34aafb598c1d.png)
开启效果如下所示。
![image](https://user-images.githubusercontent.com/40874312/197381025-6943b560-d691-4f51-8530-ae3e885ffa76.png)
设置界面。
![image](https://user-images.githubusercontent.com/40874312/197381034-af9e9050-54c6-41a8-a5f3-45a039f47e30.png)
